### PR TITLE
Fix installation instruction

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,8 +10,8 @@ Building Murxla
 
   git clone https://github.com/murxla/murxla.git
   cd murxla
-  cd build
   mkdir build
+  cd build
   cmake ..
   make
 


### PR DESCRIPTION
The website is currently not up-to-date with master (so the `cd build` is missing there). However I believe on master the lines are still incorrect and the lines should be interverted.