### PR TITLE
Non-standard construct emitted for SMT2

### DIFF
--- a/src/solver/smt2/smt2_solver.cpp
+++ b/src/solver/smt2/smt2_solver.cpp
@@ -1084,6 +1084,11 @@ Smt2Solver::mk_value(Sort sort, bool value)
       new Smt2Term(Op::UNDEFINED, {}, {}, {}, val));
 }
 
+const std::string add_dot(const std::string& s)
+{
+  return (s.find('.') != std::string::npos ? "" : ".0");
+}
+
 Term
 Smt2Solver::mk_value(Sort sort, const std::string& value)
 {
@@ -1115,13 +1120,13 @@ Smt2Solver::mk_value(Sort sort, const std::string& value)
       if (pos != std::string::npos)
       {
         assert(pos > 0);
-        std::string num = value.substr(0, pos - 1);
+        std::string num = value.substr(0, pos);
         std::string den = value.substr(pos + 1);
-        val << "(/ " << num << " " << den << ")";
+        val << "(/ " << num << add_dot(num) <<  " " << den << add_dot(den) << ")";
       }
       else
       {
-        val << value;
+        val << value << add_dot(value);
       }
     }
     break;

--- a/src/solver/smt2/smt2_solver.cpp
+++ b/src/solver/smt2/smt2_solver.cpp
@@ -230,7 +230,7 @@ Smt2Sort::is_fun() const
 bool
 Smt2Sort::is_real() const
 {
-  return d_kind == SORT_INT || d_kind == SORT_REAL;
+  return d_kind == SORT_REAL;
 }
 
 bool


### PR DESCRIPTION
It is always hard to know how Int and Real behave together, and what is defined in the theories. However I think that murxla require the solver to automatically convert integers to reals which is not required by the standard, I think.