### PR TITLE
Fix stack-use-after-return for the dummy statistics object in create_fsm

### DIFF
--- a/src/murxla.cpp
+++ b/src/murxla.cpp
@@ -720,8 +720,11 @@ Murxla::create_fsm(RNGenerator& rng,
                    bool in_untrace_replay_mode) const
 {
   /* Dummy statistics object for the cases were we don't want to record
-   * statistics (replay, dd). */
-  statistics::Statistics dummy_stats;
+   * statistics (replay, dd). Must outlive the returned FSM, which keeps a
+   * pointer to it and writes into it from configure() AFTER this function has
+   * returned; a plain local here is a stack-use-after-return that corrupts the
+   * caller's stack (nondeterministic crashes on the replay/dd path). */
+  static statistics::Statistics dummy_stats;
 
   if (!d_options.cmd_line_trace.empty())
   {


### PR DESCRIPTION
### Summary

`Murxla::create_fsm()` builds the returned-by-value `FSM` with a pointer to a **stack-local** `statistics::Statistics dummy_stats`. The FSM outlives the function and writes into that object after `create_fsm()` has returned, so the pointer dangles into the caller's reused stack frame. Making `dummy_stats` `static` fixes it.

### The bug

When statistics recording is disabled — the **replay** and **delta-debugging** paths (`record_stats == false`) — `create_fsm()` passes `&dummy_stats` to the `FSM` constructor:

```cpp
statistics::Statistics dummy_stats;          // stack-local
...
return FSM(..., record_stats ? d_stats : &dummy_stats, ...);
```

`FSM::configure()` (and the `new_action()` calls it makes) write into that statistics object — via `strncpy` at `fsm.hpp:667` — **after `create_fsm()` has already returned**. The FSM outlives `dummy_stats`, so those writes land in whatever now occupies the caller's stack, corrupting it. The result is nondeterministic crashes on the replay/delta-debugging path that are hard to attribute, because the corruption site and the crash site are unrelated.

### The fix

```cpp
static statistics::Statistics dummy_stats;   // outlives every FSM that points at it
```

One line; `dummy_stats` is a throwaway sink, so static lifetime is harmless and correct.

### How it was found

Fuzzing the STP solver wrapper (on our `stp` branch) with `--stp -c bitwuzla`; AddressSanitizer flagged it as `stack-use-after-return` in `create_fsm`.

### It affects `main`, independent of STP

The bug is entirely in `src/murxla.cpp` — no solver-specific code — and reproduces on `main` with two upstream solvers and **no STP in the build**:

```
murxla --bitwuzla -c cvc5 --bv --fp --arrays -t 5 -j 6     # ASAN build
```

AddressSanitizer report (pure `main`, `bitwuzla -c cvc5`):

```
ERROR: AddressSanitizer: stack-use-after-return
  #0 Murxla::create_fsm(...)  src/murxla.cpp:721     <- dummy_stats
  #2 FSM::configure()         src/fsm.cpp:358        <- writes to it after return
  #3 Murxla::run_aux(...)     src/murxla.cpp:949
  #4 Murxla::run(...)         src/murxla.cpp:274
  #5 Murxla::replay(...)      src/murxla.cpp:639
  #6 Murxla::test()           src/murxla.cpp:575
SUMMARY: stack-use-after-return  src/fsm.hpp:667 in FSM::new_action<ActionNew>()
```

It is solver-agnostic — any error that triggers a replay reaches this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
