### PR TITLE
Prefer the term's recorded sort in ShadowSolver::get_sort

### DIFF
--- a/src/solver/meta/shadow_solver.cpp
+++ b/src/solver/meta/shadow_solver.cpp
@@ -1004,8 +1004,21 @@ ShadowSolver::get_sort(Term term, SortKind sort_kind)
 {
   ShadowTerm* t = checked_cast<ShadowTerm*>(term.get());
   assert(t);
-  Sort s        = d_solver->get_sort(t->get_term(), sort_kind);
-  Sort s_shadow = d_solver_shadow->get_sort(t->get_term_shadow(), sort_kind);
+  /* Prefer the sort the underlying solver already recorded on the term. For
+   * some solvers (e.g. STP) get_sort() reconstructs array sorts from bit-widths
+   * alone and cannot recover FP/RM element types, so it returns a sort that
+   * differs from the one the array was created with (e.g. (Array BV FP) comes
+   * back as (Array BV BV)). That mismatched sort fails to deduplicate against
+   * the registered sort, its index/element children are lost, and reading them
+   * later crashes. The term itself carries the correct sort (set by mk_term),
+   * so use it when available and only fall back to get_sort() otherwise. */
+  Sort s = t->get_term()->get_sort();
+  if (s == nullptr) s = d_solver->get_sort(t->get_term(), sort_kind);
+  Sort s_shadow = t->get_term_shadow()->get_sort();
+  if (s_shadow == nullptr)
+  {
+    s_shadow = d_solver_shadow->get_sort(t->get_term_shadow(), sort_kind);
+  }
   std::shared_ptr<ShadowSort> res(new ShadowSort(s, s_shadow));
   return res;
 }


### PR DESCRIPTION
### Summary

`ShadowSolver::mk_term` never records a sort on the `ShadowTerm` it returns, so `SolverManager::add_term` always falls back to `ShadowSolver::get_sort`, which reconstructs the sort from the underlying solver's `get_sort`. When that reconstruction is **lossy** (e.g. an array sort rebuilt from bit-widths, losing the FP/RM element type), the reconstructed sort no longer matches the one the array was created with, fails to deduplicate, loses its index/element children, and later crashes. Fix: prefer the sort the wrapped term already carries, falling back to `get_sort` only when it has none.

### The bug

`SolverManager::add_term` uses the term's own sort first, and only reconstructs when it is missing:

```cpp
Sort sort = term->get_sort();
if (sort == nullptr) sort = d_solver->get_sort(term, sort_kind);
```

But `ShadowSolver::mk_term` returns `new ShadowTerm(t, t_shadow)` **without setting a sort**, so the fallback always runs and reaches `ShadowSolver::get_sort`, which did:

```cpp
Sort s        = d_solver->get_sort(t->get_term(), sort_kind);         // primary
Sort s_shadow = d_solver_shadow->get_sort(t->get_term_shadow(), ...); // reference
return std::make_shared<ShadowSort>(s, s_shadow);
```

For a solver whose `get_sort` cannot fully recover a sort from its node, `s` is wrong. STP, for instance, rebuilds an array sort from bit-widths alone and cannot distinguish an FP/RM element from a bit-vector of the same width, so `(Array BV FP)` comes back as `(Array BV BV)`. The consequences: `find_sort` cannot deduplicate the reconstructed sort against the registered one (`ShadowSort::equals`/`hash` compare the wrapped sorts), so the reconstructed, **childless** `ShadowSort` is used, and reading its index/element children then aborts (assertion in `SolverManager::add_sort`, `solver_manager.cpp:366`) or, in a release build, null-dereferences copying `sorts[0]` in `ActionMkTerm::generate` for `ARRAY_SELECT` (`action.cpp:1460`).

### The fix

```cpp
Sort s = t->get_term()->get_sort();
if (s == nullptr) s = d_solver->get_sort(t->get_term(), sort_kind);
Sort s_shadow = t->get_term_shadow()->get_sort();
if (s_shadow == nullptr)
  s_shadow = d_solver_shadow->get_sort(t->get_term_shadow(), sort_kind);
return std::make_shared<ShadowSort>(s, s_shadow);
```

This mirrors `add_term`'s own logic per wrapped solver: use the term's authoritative recorded sort, and only reconstruct via `get_sort` when there is none.

### How it was found

Fuzzing the STP solver wrapper (our `stp` branch) with `--stp -c bitwuzla` over floating-point arrays. STP is a natural trigger: its `get_sort` is lossy for arrays, but its wrapper records the correct sort on array-valued terms — which is exactly the sort this fix uses.

### It affects `main`, independent of STP — reproducing with a "buggy" bitwuzla

The buggy code is entirely in `src/solver/meta/shadow_solver.cpp`; STP is only the *trigger*. Stock bitwuzla and cvc5 have faithful typed array sorts, so `bitwuzla -c cvc5` will not hit it. To exercise the path on `main` with **no STP**, make bitwuzla's wrapper behave like a lossy solver — two small edits to `src/solver/bitwuzla/bitwuzla_solver.cpp`:

**(1) Make `get_sort` lossy** — collapse an FP array element to a same-width bit-vector, so `(Array BV FP)` reconstructs as `(Array BV BV)`:

```cpp
Sort BitwuzlaSolver::get_sort(Term term, SortKind sort_kind) {
  (void) sort_kind;
  ::bitwuzla::Sort s = BitwuzlaTerm::get_bitwuzla_term(term).sort();
  if (s.is_array() && s.array_element().is_fp()) {
    ::bitwuzla::Sort elem = s.array_element();
    uint64_t w = elem.fp_exp_size() + elem.fp_sig_size();
    s = d_tm->mk_array_sort(s.array_index(), d_tm->mk_bv_sort(w));
  }
  return std::shared_ptr<BitwuzlaSort>(new BitwuzlaSort(d_tm.get(), s));
}
```

**(2) Record the correct sort on array results** — add before `return res;` in `BitwuzlaSolver::mk_term`:

```cpp
  if (bzla_res.sort().is_array()) {
    res->set_sort(std::shared_ptr<BitwuzlaSort>(
        new BitwuzlaSort(d_tm.get(), bzla_res.sort())));
  }
```

Then, on an AddressSanitizer build:

```
murxla --bitwuzla -c cvc5 --bv --fp --arrays -t 5 -j 6
```

**Expected:** without this PR, `SEGV` at `action.cpp:1460` (release) or the assertion at `solver_manager.cpp:366` (debug) within seconds — the identical crash STP produces natively. With this PR, clean.

**Why part (2) is needed:** part (1) alone makes the correct sort exist *nowhere* — neither `get_sort` nor the term carry it — which is a state no functioning solver is in. Part (2) restores the invariant every real solver satisfies: the term carries its true sort. STP naturally has both properties (lossy `get_sort`, wrapper-recorded sort); this makes bitwuzla a faithful mirror, and lets you confirm the fix actually resolves the crash rather than masking it. In an A/B on `main` (lossy bitwuzla, both parts, `-c cvc5`), reverting only this PR's `shadow_solver.cpp` change flips the run from **0 crashes** to **dozens of `action.cpp:1460` SEGVs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
